### PR TITLE
UPDATE: propose update to blast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   - phylotyper genome stx2 out example_data/genome.fasta
   - phylotyper genome eae out example_data/genome.fasta
 after_failure:
+  # This should not trip after we've update the blast ver.
   - conda update -y blast
   - phylotyper genome stx1 out example_data/genome.fasta
   - phylotyper genome stx2 out example_data/genome.fasta

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ script:
   - phylotyper genome eae out example_data/genome.fasta
 after_failure:
   # This should not trip after we've update the blast ver.
+  - conda env export | grep blast
   - conda update -y blast
+  - conda env export | grep blast
   - phylotyper genome stx1 out example_data/genome.fasta
   - phylotyper genome stx2 out example_data/genome.fasta
   - phylotyper genome eae out example_data/genome.fasta

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 after_failure:
   # This should not trip after we've update the blast ver.
   - conda env export | grep blast
-  - conda update -y blast
+  - conda update -c bioconda -c conda-forge -y blast
   - conda env export | grep blast
   - phylotyper genome stx1 out example_data/genome.fasta
   - phylotyper genome stx2 out example_data/genome.fasta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo: required
+lanugage: python
+python:
+  - "2.7"
+before_install:
+  - sudo apt-get update
+  # Install miniconda.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+install:
+  - conda create --name phylotyper
+  - source activate phylotyper
+  - conda install -c mdwhitesi -c bioconda -c conda-forge -c compbiocore phylotyper
+  - mkdir out
+script:
+  - phylotyper genome stx1 out example_data/genome.fasta
+  - phylotyper genome stx2 out example_data/genome.fasta
+  - phylotyper genome eae out example_data/genome.fasta
+after_failure:
+  - conda update -y blast
+  - phylotyper genome stx1 out example_data/genome.fasta
+  - phylotyper genome stx2 out example_data/genome.fasta
+  - phylotyper genome eae out example_data/genome.fasta
+notifications:
+  email: false

--- a/conda/phylotyper/meta.yaml
+++ b/conda/phylotyper/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
   fn: master.zip
   url: https://github.com/superphy/insilico-subtyping/archive/master.zip
-  # md5: 
+  # md5:
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -29,7 +29,7 @@ build:
 
 requirements:
   build:
-    - python 
+    - python
     - biopython
     - rpy2 <=2.8
     - setuptools
@@ -51,13 +51,13 @@ requirements:
     - r-igraph
     - bioconductor-biostrings
     - mafft
-    - blast 2.6.0
+    - blast >= 2.6.0
     - fasttree
-    - trimal 
+    - trimal
 
   run:
-    - python 
-    - biopython 
+    - python
+    - biopython
     - rpy2 <=2.8
     - setuptools
     - pytest
@@ -78,7 +78,7 @@ requirements:
     - r-igraph
     - bioconductor-biostrings
     - mafft
-    - blast
+    - blast >= 2.7.1
     - fasttree
     - trimal
 


### PR DESCRIPTION
Hey Matt,

Was getting this error https://rt.cpan.org/Public/Bug/Display.html?id=121336 when blast was running on `- blast=2.5.0=0`. I updated blast manually to `2.7.1` and it resolved the issue. The PR pins the newer blast ver. in our conda build, but we should check it isn't incompatible with another dep.

I've added a .travis config that should recreate the issue.

```
(phylotyper) kevin@kevin-ThinkPad-T510:~/Desktop$ phylotyper genome stx2 temp/ test_stx2_genome1.fasta
INFO:phylotyper.main:No config file argument. Using default settings.
You can provide a Phylotyper config file using enviroment variable PHYLOTYPER_CONFIG or command-line argument --config.
INFO:phylotyper.main:Settings:
{'alignment': ['/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_reference0.affn',
               '/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_reference1.affn'],
 'desc': 'Escherichia coli Shiga-toxin 2 (Stx2) subtype',
 'fast': False,
 'genomes': ['/home/kevin/Desktop/test_stx2_genome1.fasta'],
 'input': ['/home/kevin/Desktop/temp/search_results.locus0',
           '/home/kevin/Desktop/temp/search_results.locus1'],
 'lookup': '/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_dictionary.json',
 'ngenomes': 1,
 'nloci': 2,
 'noplots': False,
 'output_directory': '/home/kevin/Desktop/temp',
 'rate_matrix': '/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_rate_matrix.rds',
 'result': '/home/kevin/Desktop/temp/subtype_predictions.tsv',
 'search_database': '/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_search_database',
 'seq': 'aa',
 'subtype': '/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_subtypes.csv'}
INFO:phylotyper.main:Config:
R:
    rscript: Rscript
    repo: None
    lib: None
external:
    blastx: blastx
    blastdbcmd: blastdbcmd
    makeblastdb: makeblastdb
    fasttree: FastTree
    trimal: trimal
    blastn: blastn
    mafft: mafft
phylotyper:
    prediction_threshold: 0.9

Traceback (most recent call last):
  File "/home/kevin/miniconda2/envs/phylotyper/bin/phylotyper", line 11, in <module>
    sys.exit(main())
  File "/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/run.py", line 698, in main
    subtype_pipeline(subtype_options, config)
  File "/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/run.py", line 205, in subtype_pipeline
    detector = LociSearch(config, options['search_database'], None, seqtype, options['nloci'])
  File "/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/genome/loci.py", line 123, in __init__
    self.load_db(database)
  File "/home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/genome/loci.py", line 209, in load_db
    raise Exception(msg)
Exception: LociSearch command blastdbcmd -db /home/kevin/miniconda2/envs/phylotyper/lib/python2.7/site-packages/phylotyper-0.1.0-py2.7.egg/phylotyper/data/stx2/stx2_search_database -entry all -outfmt "%t	%l" failed: Error: [blastdbcmd] CObject_id::GetId(): Invalid choice selection: NCBI-General::Object-id.str
ptloci1|Stx2a-E-cloacae-95MV2	320
ptloci1|Stx2a-O101-EBC201	320
ptloci1|Stx2a-O104-G5506	320
ptloci1|Stx2a-O111-928-91	320
ptloci1|Stx2a-O113-CL-3	320
ptloci1|Stx2a-O113-TS17-08	320
ptloci1|Stx2a-O113-TS17-08-1	320
ptloci1|Stx2a-O113-TS17-08-2	320
ptloci1|Stx2a-O113-TS17-08-3	320
ptloci1|Stx2a-O113-TS17-08-4	320
ptloci1|Stx2a-O113-TS17-08-5	320
ptloci1|Stx2a-O136-VTB60	320
ptloci1|Stx2a-O157-16581	320
ptloci1|Stx2a-O157-93-111	320
ptloci1|Stx2a-O157-A397	320
ptloci1|Stx2a-O157-EDL933	320
ptloci1|Stx2a-O157-EDL933-1	320
ptloci1|Stx2a-O157-EDL933-2	320
ptloci1|Stx2a-O157-SF-258-98	320
ptloci1|Stx2a-O178-TS22-08	320
ptloci1|Stx2a-O22-EBC217	320
ptloci1|Stx2a-O26-126814	320
ptloci1|Stx2a-O26-FD930	320
ptloci1|Stx2a-O48-94C	320
ptloci1|Stx2a-O48-94C-1	320
ptloci1|Stx2a-O48-94C-2	320
ptloci1|Stx2a-O48-94C-3	320
ptloci1|Stx2a-O48-94C-4	320
ptloci1|Stx2a-O48-94C-5	320
ptloci1|Stx2a-O8-VTB178	320
ptloci1|Stx2a-O8-VTB178-1	320
ptloci1|Stx2a-ONT-23765	320
ptloci1|Stx2a-ONT-EBC210	320
ptloci1|Stx2b-O111-PH	320
ptloci1|Stx2b-O111-S-1	320
ptloci1|Stx2b-O111-S-3	320
ptloci1|Stx2b-O118-EH250	320
ptloci1|Stx2b-O128-24196-97	320
ptloci1|Stx2b-O174-031	320
ptloci1|Stx2b-O22-3143-97	320
ptloci1|Stx2b-O40-5293-98	320
ptloci1|Stx2b-O8-S-9	320
ptloci1|Stx2b-O93-S-5	320
ptloci1|Stx2b-O96-S-10	320
ptloci1|Stx2b-O96-S-6	320
ptloci1|Stx2b-O96-S-7	320
ptloci1|Stx2b-ONT-I7606	318
ptloci1|Stx2b-Out-HI-N	320
ptloci1|Stx2b-Out-S-4	320
ptloci1|Stx2c-O157-020324	320
ptloci1|Stx2c-O157-310	320
ptloci1|Stx2c-O157-310-1	320
ptloci1|Stx2c-O157-469	320
ptloci1|Stx2c-O157-A75	320
ptloci1|Stx2c-O157-C394-03	320
ptloci1|Stx2c-O157-E32511	320
ptloci1|Stx2c-O157-FLY16	320
ptloci1|Stx2c-O157-FLY16-1	320
ptloci1|Stx2c-O157-FLY16-2	320
ptloci1|Stx2c-O157-FLY16-3	320
ptloci1|Stx2c-O157-G5101	320
ptloci1|Stx2c-O157-V20	320
ptloci1|Stx2c-O157-Y350-1	320
ptloci1|Stx2c-O171-EBC287	320
ptloci1|Stx2c-O174-031	320
ptloci1|Stx2c-O177-06-5121	320
ptloci1|Stx2c-O177-06-5121-1	320
ptloci1|Stx2c-O177-CB7126	320
ptloci1|Stx2c-ONT-EBC219	320
ptloci1|Stx2c-ONT-EBC289	320
ptloci1|Stx2c-ONT-pVTEC9	320
ptloci1|Stx2c-OR-TS27-08	320
ptloci1|Stx2c-OR-TS27-08-1	320
ptloci1|Stx2d-O91-B2F1-1	320
ptloci1|Stx2d-O91-B2F1-2	320
ptloci1|Stx2d-C-freundii-LM76	321
ptloci1|Stx2d-O103-pVTEC7	320
ptloci1|Stx2d-O113-TS03-07	320
ptloci1|Stx2d-O113-TS21-08	320
ptloci1|Stx2d-O113-TS21-08-1	320
ptloci1|Stx2d-O157-7279	320
ptloci1|Stx2d-O174-EC1720a	320
ptloci1|Stx2d-O174-EC173b	320
ptloci1|Stx2d-O174-EC173b-1	320
ptloci1|Stx2d-O174-EC173b-2	320
ptloci1|Stx2d-O174-EC173b-3	320
ptloci1|Stx2d-O174-EC173b-4	320
ptloci1|Stx2d-O174-EC173b-5	320
ptloci1|Stx2d-O174-EC173b-6	320
ptloci1|Stx2d-O174-EC173b-7	320
ptloci1|Stx2d-O2-EC604a	320
ptloci1|Stx2d-O55-5905	320
ptloci1|Stx2d-O6-NV206	320
ptloci1|Stx2d-O73-C165-02	320
ptloci1|Stx2d-O8-C466-01B	320
ptloci1|Stx2d-ONT-EBC275	320
ptloci1|Stx2d-ONT-EC1871a	320
ptloci1|Stx2d-O28-MT71	320
ptloci1|Stx2e-O8-FHI-1106-1092	320
ptloci1|Stx2e-O100-TS01-07	320
ptloci1|Stx2e-O101-E-D42	320
ptloci1|Stx2e-O101-E-D43	320
ptloci1|Stx2e-O101-E-D53	320
ptloci1|Stx2e-O101-E-D68	320
ptloci1|Stx2e-O121-NP9621	320
ptloci1|Stx2e-O139-S1191	320
ptloci1|Stx2e-O22-3615-99	320
ptloci1|Stx2e-O22-3615-99-1	320
ptloci1|Stx2e-O22-3615-99-2	320
ptloci1|Stx2e-O22-3615-99-3	320
ptloci1|Stx2e-O26-R107	320
ptloci1|Stx2e-ONT-2771	320
ptloci1|Stx2e-ONT-TS03-08	320
ptloci1|Stx2e-ONT-TS29-08	320
ptloci1|Stx2e-OR-TS09-07	320
ptloci1|Stx2f-O115-F08-101-31	320
ptloci1|Stx2f-O128-T4-97	320
ptloci1|Stx2f-O128-T4-97-1	320
ptloci1|Stx2g-O2-7v	320
ptloci1|Stx2g-O2-HI-11	320
ptloci1|Stx2g-O2-S86	320
ptloci1|Stx2g-Out-S-8	320
ptloci2|Stx2a-Acinetobacter_haemolyticus	90
ptloci2|Stx2a-E-cloacae-95MV2	90
ptloci2|Stx2a-O101-EBC201	90
ptloci2|Stx2a-O104-G5506	90
ptloci2|Stx2a-O111-928-91	90
ptloci2|Stx2a-O113-CL-3	90
ptloci2|Stx2a-O113-TS17-08	90
ptloci2|Stx2a-O113-TS17-08-1	90
ptloci2|Stx2a-O113-TS17-08-2	90
ptloci2|Stx2a-O113-TS17-08-3	90
ptloci2|Stx2a-O113-TS17-08-4	90
ptloci2|Stx2a-O113-TS17-08-5	90
ptloci2|Stx2a-O136-VTB60	90
ptloci2|Stx2a-O157-16581	90
ptloci2|Stx2a-O157-93-111	90
ptloci2|Stx2a-O157-A397	90
ptloci2|Stx2a-O157-EDL933	90
ptloci2|Stx2a-O157-EDL933-1	90
ptloci2|Stx2a-O157-EDL933-2	90
ptloci2|Stx2a-O157-SF-258-98	90
ptloci2|Stx2a-O178-TS22-08	90
ptloci2|Stx2a-O22-EBC217	90
ptloci2|Stx2a-O26-126814	90
ptloci2|Stx2a-O26-FD930	90
ptloci2|Stx2a-O48-94C	90
ptloci2|Stx2a-O48-94C-1	90
ptloci2|Stx2a-O48-94C-2	90
ptloci2|Stx2a-O48-94C-3	90
ptloci2|Stx2a-O48-94C-4	90
ptloci2|Stx2a-O48-94C-5	90
ptloci2|Stx2a-O8-VTB178	90
ptloci2|Stx2a-O8-VTB178-1	90
ptloci2|Stx2a-ONT-23765	90
ptloci2|Stx2a-ONT-EBC210	90
ptloci2|Stx2b-O111-PH	88
ptloci2|Stx2b-O111-S-1	90
ptloci2|Stx2b-O111-S-3	90
ptloci2|Stx2b-O118-EH250	88
ptloci2|Stx2b-O128-24196-97	88
ptloci2|Stx2b-O174-031	88
ptloci2|Stx2b-O22-3143-97	88
ptloci2|Stx2b-O40-5293-98	88
ptloci2|Stx2b-O8-S-9	90
ptloci2|Stx2b-O93-S-5	90
ptloci2|Stx2b-O96-S-10	90
ptloci2|Stx2b-O96-S-6	90
ptloci2|Stx2b-O96-S-7	90
ptloci2|Stx2b-ONT-I7606	90
ptloci2|Stx2b-Out-HI-N	90
ptloci2|Stx2b-Out-S-4	90
ptloci2|Stx2c-O157-020324	90
ptloci2|Stx2c-O157-310	90
ptloci2|Stx2c-O157-310-1	90
ptloci2|Stx2c-O157-469	90
ptloci2|Stx2c-O157-A75	90
ptloci2|Stx2c-O157-C394-03	90
ptloci2|Stx2c-O157-E32511	90
ptloci2|Stx2c-O157-FLY16	90
ptloci2|Stx2c-O157-FLY16-1	90
ptloci2|Stx2c-O157-FLY16-2	90
ptloci2|Stx2c-O157-FLY16-3	90
ptloci2|Stx2c-O157-G5101	90
ptloci2|Stx2c-O157-V20	90
ptloci2|Stx2c-O157-Y350-1	90
ptloci2|Stx2c-O171-EBC287	90
ptloci2|Stx2c-O174-031	90
ptloci2|Stx2c-O177-06-5121	90
ptloci2|Stx2c-O177-06-5121-1	90
ptloci2|Stx2c-O177-CB7126	90
ptloci2|Stx2c-ONT-EBC219	90
ptloci2|Stx2c-ONT-EBC289	90
ptloci2|Stx2c-ONT-pVTEC9	90
ptloci2|Stx2c-OR-TS27-08	90
ptloci2|Stx2c-OR-TS27-08-1	90
ptloci2|Stx2d-O91-B2F1-1	90
ptloci2|Stx2d-O91-B2F1-2	90
ptloci2|Stx2d-C-freundii-LM76	90
ptloci2|Stx2d-O103-pVTEC7	90
ptloci2|Stx2d-O113-TS03-07	90
ptloci2|Stx2d-O113-TS21-08	90
ptloci2|Stx2d-O113-TS21-08-1	90
ptloci2|Stx2d-O157-7279	90
ptloci2|Stx2d-O174-EC1720a	90
ptloci2|Stx2d-O174-EC173b	90
ptloci2|Stx2d-O174-EC173b-1	90
ptloci2|Stx2d-O174-EC173b-2	90
ptloci2|Stx2d-O174-EC173b-3	90
ptloci2|Stx2d-O174-EC173b-4	90
ptloci2|Stx2d-O174-EC173b-5	90
ptloci2|Stx2d-O174-EC173b-6	90
ptloci2|Stx2d-O174-EC173b-7	90
ptloci2|Stx2d-O2-EC604a	90
ptloci2|Stx2d-O55-5905	90
ptloci2|Stx2d-O6-NV206	90
ptloci2|Stx2d-O73-C165-02	90
ptloci2|Stx2d-O8-C466-01B	90
ptloci2|Stx2d-ONT-EBC275	90
ptloci2|Stx2d-ONT-EC1871a	90
ptloci2|Stx2d-O28-MT71	90
ptloci2|Stx2e-O8-FHI-1106-1092	90
ptloci2|Stx2e-O100-TS01-07	88
ptloci2|Stx2e-O101-E-D42	88
ptloci2|Stx2e-O101-E-D43	88
ptloci2|Stx2e-O101-E-D53	88
ptloci2|Stx2e-O101-E-D68	88
ptloci2|Stx2e-O121-NP9621	88
ptloci2|Stx2e-O139-S1191	88
ptloci2|Stx2e-O22-3615-99	88
ptloci2|Stx2e-O22-3615-99-1	88
ptloci2|Stx2e-O22-3615-99-2	88
ptloci2|Stx2e-O22-3615-99-3	88
ptloci2|Stx2e-O26-R107	88
ptloci2|Stx2e-ONT-2771	88
ptloci2|Stx2e-ONT-TS03-08	88
ptloci2|Stx2e-ONT-TS29-08	88
ptloci2|Stx2e-OR-TS09-07	88
ptloci2|Stx2f-O115-F08-101-31	88
ptloci2|Stx2f-O128-T4-97	88
ptloci2|Stx2f-O128-T4-97-1	88
ptloci2|Stx2g-O2-7v	90
ptloci2|Stx2g-O2-HI-11	90
ptloci2|Stx2g-O2-S86	90
ptloci2|Stx2g-Out-S-8	90
 (return code: 1).
```